### PR TITLE
Add mobile hamburger menu to navigation

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -7,7 +7,7 @@ const isDDL = currentPath.startsWith('/ars_sicilia/ddl/');
 
 <header class="header-sticky">
   <div class="container-custom py-5">
-    <div class="flex items-center justify-between gap-6 flex-wrap md:flex-nowrap">
+    <div class="flex items-center justify-between gap-6 relative">
       <!-- Logo e titolo editoriale -->
       <div class="flex-shrink-0">
         <a href="/ars_sicilia/" class="block group">
@@ -28,14 +28,30 @@ const isDDL = currentPath.startsWith('/ars_sicilia/ddl/');
         </a>
       </div>
 
+      <!-- Hamburger button (mobile only) -->
+      <button
+        id="mobile-menu-button"
+        type="button"
+        class="md:hidden flex items-center justify-center w-10 h-10 rounded-md text-navy-800 hover:bg-navy-100 transition-colors"
+        aria-label="Toggle menu"
+        aria-expanded="false"
+      >
+        <svg id="menu-icon" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        <svg id="close-icon" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+
       <!-- Navigazione -->
-      <nav aria-label="Navigazione principale" class="flex-shrink-0">
-        <ul class="flex gap-4 md:gap-6 items-center flex-wrap">
-          <li>
+      <nav id="mobile-menu" aria-label="Navigazione principale" class="hidden md:flex flex-shrink-0 absolute md:relative top-full left-0 right-0 md:top-auto bg-white md:bg-transparent border-b-2 md:border-b-0 border-warm-200 md:border-0 shadow-lg md:shadow-none">
+        <ul class="flex flex-col md:flex-row gap-0 md:gap-6 items-stretch md:items-center w-full md:w-auto p-4 md:p-0">
+          <li class="w-full md:w-auto">
             <a
               href="/ars_sicilia/"
               class:list={[
-                'font-semibold text-sm md:text-base transition-all duration-200 px-3 py-1.5 rounded-md',
+                'font-semibold text-sm md:text-base transition-all duration-200 px-3 py-2.5 md:py-1.5 rounded-md block md:inline-block text-center md:text-left',
                 isHome
                   ? 'text-white bg-navy-800 shadow-sm'
                   : 'text-navy-800 hover:bg-navy-100 hover:text-navy-900',
@@ -45,11 +61,11 @@ const isDDL = currentPath.startsWith('/ars_sicilia/ddl/');
               Home
             </a>
           </li>
-          <li>
+          <li class="w-full md:w-auto">
             <a
               href="/ars_sicilia/sedute/1"
               class:list={[
-                'font-semibold text-sm md:text-base transition-all duration-200 px-3 py-1.5 rounded-md',
+                'font-semibold text-sm md:text-base transition-all duration-200 px-3 py-2.5 md:py-1.5 rounded-md block md:inline-block text-center md:text-left',
                 isSedute
                   ? 'text-white bg-navy-800 shadow-sm'
                   : 'text-navy-800 hover:bg-navy-100 hover:text-navy-900',
@@ -59,11 +75,11 @@ const isDDL = currentPath.startsWith('/ars_sicilia/ddl/');
               Sedute
             </a>
           </li>
-          <li>
+          <li class="w-full md:w-auto">
             <a
               href="/ars_sicilia/ddl/1"
               class:list={[
-                'font-semibold text-sm md:text-base transition-all duration-200 px-3 py-1.5 rounded-md',
+                'font-semibold text-sm md:text-base transition-all duration-200 px-3 py-2.5 md:py-1.5 rounded-md block md:inline-block text-center md:text-left',
                 isDDL
                   ? 'text-white bg-navy-800 shadow-sm'
                   : 'text-navy-800 hover:bg-navy-100 hover:text-navy-900',
@@ -73,20 +89,20 @@ const isDDL = currentPath.startsWith('/ars_sicilia/ddl/');
               DDL
             </a>
           </li>
-          <li>
+          <li class="w-full md:w-auto">
             <a
               href="/ars_sicilia/about"
-              class="font-semibold text-sm md:text-base text-navy-800 hover:bg-navy-100 hover:text-navy-900 transition-all duration-200 px-3 py-1.5 rounded-md"
+              class="font-semibold text-sm md:text-base text-navy-800 hover:bg-navy-100 hover:text-navy-900 transition-all duration-200 px-3 py-2.5 md:py-1.5 rounded-md block md:inline-block text-center md:text-left"
             >
               Info
             </a>
           </li>
-          <li>
+          <li class="w-full md:w-auto">
             <a
               href="https://www.ars.sicilia.it/agenda/lavori-aula"
               target="_blank"
               rel="noopener noreferrer"
-              class="font-semibold text-sm md:text-base text-warm-600 hover:text-navy-800 hover:bg-warm-100 transition-all duration-200 px-3 py-1.5 rounded-md inline-flex items-center gap-1"
+              class="font-semibold text-sm md:text-base text-warm-600 hover:text-navy-800 hover:bg-warm-100 transition-all duration-200 px-3 py-2.5 md:py-1.5 rounded-md flex md:inline-flex items-center justify-center gap-1"
             >
               Sito ARS
               <svg class="w-3 h-3 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -95,13 +111,13 @@ const isDDL = currentPath.startsWith('/ars_sicilia/ddl/');
               <span class="sr-only">(apre in una nuova finestra)</span>
             </a>
           </li>
-          <li>
+          <li class="w-full md:w-auto">
             <a
               href="/ars_sicilia/rss.xml"
               target="_blank"
               rel="alternate"
               type="application/rss+xml"
-              class="inline-flex items-center gap-1.5 font-semibold text-sm md:text-base text-amber-600 hover:text-amber-700 hover:bg-amber-50 transition-all duration-200 px-3 py-1.5 rounded-md"
+              class="flex md:inline-flex items-center justify-center gap-1.5 font-semibold text-sm md:text-base text-amber-600 hover:text-amber-700 hover:bg-amber-50 transition-all duration-200 px-3 py-2.5 md:py-1.5 rounded-md"
               aria-label="Feed RSS"
               title="Feed RSS"
             >
@@ -116,3 +132,41 @@ const isDDL = currentPath.startsWith('/ars_sicilia/ddl/');
     </div>
   </div>
 </header>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const menuButton = document.getElementById('mobile-menu-button');
+    const mobileMenu = document.getElementById('mobile-menu');
+    const menuIcon = document.getElementById('menu-icon');
+    const closeIcon = document.getElementById('close-icon');
+
+    if (menuButton && mobileMenu && menuIcon && closeIcon) {
+      menuButton.addEventListener('click', () => {
+        const isExpanded = menuButton.getAttribute('aria-expanded') === 'true';
+
+        // Toggle menu visibility
+        mobileMenu.classList.toggle('hidden');
+
+        // Toggle icons
+        menuIcon.classList.toggle('hidden');
+        closeIcon.classList.toggle('hidden');
+
+        // Update aria-expanded
+        menuButton.setAttribute('aria-expanded', !isExpanded);
+      });
+
+      // Close menu when clicking on a link (mobile only)
+      const menuLinks = mobileMenu.querySelectorAll('a');
+      menuLinks.forEach(link => {
+        link.addEventListener('click', () => {
+          if (window.innerWidth < 768) {
+            mobileMenu.classList.add('hidden');
+            menuIcon.classList.remove('hidden');
+            closeIcon.classList.add('hidden');
+            menuButton.setAttribute('aria-expanded', 'false');
+          }
+        });
+      });
+    }
+  });
+</script>


### PR DESCRIPTION
Implement responsive hamburger menu for mobile devices that:
- Shows hamburger icon on mobile screens (< 768px)
- Hides navigation menu by default on mobile
- Toggles menu visibility when hamburger is clicked
- Displays menu items vertically on mobile
- Maintains horizontal layout on desktop
- Closes menu automatically when a link is clicked on mobile
- Includes proper ARIA attributes for accessibility